### PR TITLE
Add Docker Compose for local MongoDB development

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,20 @@
 ### Pre-requisite and Installing Steps
 
 * Install Java 17.
-* Get a running instance of MongoDB that you can connect to.
-For more information on getting started with MongoDB, visit their [online tutorial](https://docs.mongodb.com/manual/).
+* Install Docker and Docker Compose if you want the recommended local MongoDB setup.
 * Copy `.env.example` into your local environment configuration and set the values for your machine:
   * `SERVER_PORT`
   * `MONGODB_URI`
   * `JWT_SECRET`
   * `JWT_EXPIRATION_MS`
-* Start by creating a test database. I will call mine "rest_tutorial" using the following command in the MongoDB shell, or through a database manager like MongoDB Compass:
+* Start MongoDB locally with Docker Compose:
+```bash
+docker compose up -d mongodb
+```
+  This starts MongoDB on `localhost:27017` and stores database files in the named `mongodb_data` Docker volume. The default `.env.example` value, `MONGODB_URI=mongodb://localhost:27017/rest_tutorial`, connects the app to this container.
+* If you prefer to manage MongoDB yourself, get a running instance of MongoDB that you can connect to.
+For more information on getting started with MongoDB, visit their [online tutorial](https://docs.mongodb.com/manual/).
+* Start by creating a test database. I will call mine "rest_tutorial" using the following command in the MongoDB shell, Docker Compose container, or through a database manager like MongoDB Compass:
 ```use rest_tutorial;```
 
 * Create a sample collection that will hold data about different types of pets. Let's create the collection with the following command:
@@ -76,6 +82,26 @@ db.roles.insertMany([
    { name: "ROLE_MODERATOR" },
    { name: "ROLE_ADMIN" },
 ])
+```
+
+### Running the application locally
+
+After MongoDB is running and your environment variables are configured, start the API with Gradle:
+
+```bash
+./gradlew bootRun
+```
+
+The application uses `MONGODB_URI=mongodb://localhost:27017/rest_tutorial` by default for local Docker Compose development. To stop the MongoDB container when you are done, run:
+
+```bash
+docker compose down
+```
+
+Add `-v` to remove the persisted `mongodb_data` volume as well:
+
+```bash
+docker compose down -v
 ```
 
 ### Running the tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  mongodb:
+    image: mongo:7
+    container_name: springboot-restapi-mongodb
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  mongodb_data:


### PR DESCRIPTION
### Motivation
- Provide an easy, reproducible local MongoDB for contributors to run the API without manual MongoDB installation. 
- Make the default local `MONGODB_URI` work out-of-the-box with a documented Docker Compose setup.

### Description
- Add `docker-compose.yml` that runs `mongo:7`, maps `27017:27017`, persists data to a named `mongodb_data` volume, and includes a `mongosh` ping healthcheck. 
- Update `README.md` to recommend Docker/Docker Compose for local development and show `docker compose up -d mongodb` to start MongoDB. 
- Add instructions to the `README.md` for running the application locally with `./gradlew bootRun` and for stopping/removing the Compose resources with `docker compose down` and `docker compose down -v`, and note the default `MONGODB_URI=mongodb://localhost:27017/rest_tutorial` works with the Compose service.

### Testing
- Attempted to run the project test suite with `./gradlew test`, but it was blocked because the environment could not download the Gradle distribution from `services.gradle.org` (network unreachable). 
- Attempted to validate the Compose file with `docker compose config`, but it was blocked because the Docker CLI is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d9c22e15883308c9267ef57b6b0f7)