### PR TITLE
Feat/code quality swagger lombok security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 SERVER_PORT=8081
 MONGODB_URI=mongodb://localhost:27017/rest_tutorial
-JWT_SECRET=change-this-development-secret-change-this-development-secret
+JWT_SECRET=change-this-development-secret-change-this-development-secret-ok64
 JWT_EXPIRATION_MS=86400000
+REFRESH_TOKEN_EXPIRY_DAYS=7
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,12 @@ JWT_EXPIRATION_MS=86400000
 REFRESH_TOKEN_EXPIRY_DAYS=7
 REDIS_HOST=localhost
 REDIS_PORT=6379
+
+# ── OpenAPI / Swagger metadata (optional overrides) ──────────────────────────
+# Change these when you fork this repo so Swagger UI shows your details
+OPENAPI_TITLE=SpringBoot REST API — Pets
+OPENAPI_VERSION=1.0.0
+OPENAPI_CONTACT_NAME=saivamsikaruturi
+OPENAPI_CONTACT_URL=https://github.com/saivamsikaruturi/SpringBootRestAPI
+OPENAPI_LICENSE_NAME=MIT License
+OPENAPI_LICENSE_URL=https://github.com/saivamsikaruturi/SpringBootRestAPI/blob/master/LICENSE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,68 @@
-name: CI
+name: CI — Build & Test
 
 on:
-  pull_request:
   push:
-    branches:
-      - master
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:
+    name: Build & Test (Java 21)
     runs-on: ubuntu-latest
 
+    # ── Service containers (MongoDB for tests) ──────────────────────────────
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval \"db.adminCommand('ping')\""
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    # ── Steps ───────────────────────────────────────────────────────────────
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Java
+      - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 17
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
 
-      - name: Build and test
-        run: sh ./gradlew clean build
+      - name: Build and run tests
+        env:
+          SERVER_PORT: 8081
+          MONGODB_URI: mongodb://localhost:27017/rest_tutorial
+          JWT_SECRET: ci-test-secret-value-minimum-64-chars-required-for-hs512-algorithm
+          JWT_EXPIRATION_MS: 3600000
+        run: ./gradlew clean test jacocoTestReport --no-daemon
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/reports/tests/test/
+
+      - name: Upload JaCoCo coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html/
+
+      - name: Upload coverage to Codecov
+        if: success()
+        uses: codecov/codecov-action@v4
+        with:
+          files: build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ description = """restApi"""
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -26,18 +26,43 @@ repositories {
 }
 
 dependencies {
+    // Core
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // Redis (for JWT blacklist production profile)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Actuator (health + info endpoints)
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // OpenAPI / Swagger UI
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Testcontainers
+    testImplementation 'org.testcontainers:testcontainers:1.20.4'
+    testImplementation 'org.testcontainers:junit-jupiter:1.20.4'
+    testImplementation 'org.testcontainers:mongodb:1.20.4'
+
+    // Lombok for tests
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {
@@ -56,10 +81,20 @@ jacocoTestReport {
     }
 }
 
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.70
+            }
+        }
+    }
+}
+
 check.dependsOn jacocoTestReport
 
 sonar {
     properties {
-        property 'sonar.projectKey', 'GouravRusiya30_SpringBootRestAPI'
+        property 'sonar.projectKey', 'saivamsikaruturi_SpringBootRestAPI'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,6 @@ check.dependsOn jacocoTestReport
 
 sonar {
     properties {
-        property 'sonar.projectKey', 'saivamsikaruturi_SpringBootRestAPI'
+        property 'sonar.projectKey', 'GouravRusiya30_SpringBootRestAPI'
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,21 @@ services:
       retries: 5
       start_period: 10s
 
+  redis:
+    image: redis:7-alpine
+    container_name: springboot-restapi-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
 volumes:
   mongodb_data:
+  redis_data:

--- a/src/main/java/com/gourav/restapi/RestApiApplication.java
+++ b/src/main/java/com/gourav/restapi/RestApiApplication.java
@@ -2,11 +2,12 @@ package com.gourav.restapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
+@EnableMongoAuditing
 public class RestApiApplication {
-
-	public static void main(String[] args) {
-		SpringApplication.run(RestApiApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(RestApiApplication.class, args);
+    }
 }

--- a/src/main/java/com/gourav/restapi/config/OpenApiConfig.java
+++ b/src/main/java/com/gourav/restapi/config/OpenApiConfig.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,34 +16,43 @@ public class OpenApiConfig {
 
     private static final String BEARER_AUTH = "BearerAuth";
 
+    // All values come from application.properties / environment variables.
+    // Override via env vars: OPENAPI_TITLE, OPENAPI_CONTACT_NAME, etc.
+
+    @Value("${openapi.info.title}")
+    private String title;
+
+    @Value("${openapi.info.version}")
+    private String version;
+
+    @Value("${openapi.info.description}")
+    private String description;
+
+    @Value("${openapi.info.contact.name}")
+    private String contactName;
+
+    @Value("${openapi.info.contact.url}")
+    private String contactUrl;
+
+    @Value("${openapi.info.license.name}")
+    private String licenseName;
+
+    @Value("${openapi.info.license.url}")
+    private String licenseUrl;
+
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
-                        .title("SpringBoot REST API — Pets")
-                        .version("1.0.0")
-                        .description("""
-                                A ready-to-use REST API template built with **Spring Boot 3 + MongoDB**.
-                                
-                                ## Authentication
-                                1. Register via `POST /api/auth/signup`
-                                2. Login via `POST /api/auth/login` — copy the `accessToken`
-                                3. Click **Authorize** (🔒) above and enter `<your-token>` (without "Bearer ")
-                                4. All protected endpoints will automatically include the token.
-                                
-                                ## Roles
-                                | Role | Permissions |
-                                |---|---|
-                                | USER | Read pets |
-                                | MODERATOR | Read + Update pets |
-                                | ADMIN | Full CRUD |
-                                """)
+                        .title(title)
+                        .version(version)
+                        .description(description)
                         .contact(new Contact()
-                                .name("saivamsikaruturi")
-                                .url("https://github.com/saivamsikaruturi/SpringBootRestAPI"))
+                                .name(contactName)
+                                .url(contactUrl))
                         .license(new License()
-                                .name("MIT License")
-                                .url("https://github.com/saivamsikaruturi/SpringBootRestAPI/blob/master/LICENSE")))
+                                .name(licenseName)
+                                .url(licenseUrl)))
                 .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH))
                 .components(new Components()
                         .addSecuritySchemes(BEARER_AUTH,

--- a/src/main/java/com/gourav/restapi/config/OpenApiConfig.java
+++ b/src/main/java/com/gourav/restapi/config/OpenApiConfig.java
@@ -1,0 +1,56 @@
+package com.gourav.restapi.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String BEARER_AUTH = "BearerAuth";
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("SpringBoot REST API — Pets")
+                        .version("1.0.0")
+                        .description("""
+                                A ready-to-use REST API template built with **Spring Boot 3 + MongoDB**.
+                                
+                                ## Authentication
+                                1. Register via `POST /api/auth/signup`
+                                2. Login via `POST /api/auth/login` — copy the `accessToken`
+                                3. Click **Authorize** (🔒) above and enter `<your-token>` (without "Bearer ")
+                                4. All protected endpoints will automatically include the token.
+                                
+                                ## Roles
+                                | Role | Permissions |
+                                |---|---|
+                                | USER | Read pets |
+                                | MODERATOR | Read + Update pets |
+                                | ADMIN | Full CRUD |
+                                """)
+                        .contact(new Contact()
+                                .name("saivamsikaruturi")
+                                .url("https://github.com/saivamsikaruturi/SpringBootRestAPI"))
+                        .license(new License()
+                                .name("MIT License")
+                                .url("https://github.com/saivamsikaruturi/SpringBootRestAPI/blob/master/LICENSE")))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER_AUTH,
+                                new SecurityScheme()
+                                        .name(BEARER_AUTH)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .description("Enter your JWT access token (from /api/auth/login)")));
+    }
+}

--- a/src/main/java/com/gourav/restapi/config/WebSecurityConfig.java
+++ b/src/main/java/com/gourav/restapi/config/WebSecurityConfig.java
@@ -27,15 +27,6 @@ public class WebSecurityConfig {
     }
 
     @Bean
-    public DaoAuthenticationProvider authenticationProvider(UserDetailsServiceImpl userDetailsService,
-                                                            PasswordEncoder passwordEncoder) {
-        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
-        authProvider.setUserDetailsService(userDetailsService);
-        authProvider.setPasswordEncoder(passwordEncoder);
-        return authProvider;
-    }
-
-    @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)
             throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
@@ -49,14 +40,28 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http,
                                            AuthEntryPointJwt unauthorizedHandler,
-                                           DaoAuthenticationProvider authenticationProvider) throws Exception {
+                                           UserDetailsServiceImpl userDetailsService,
+                                           PasswordEncoder passwordEncoder) throws Exception {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder);
+
         http.cors(withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authenticationProvider(authenticationProvider)
+                .authenticationProvider(authProvider)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        // Swagger UI + OpenAPI docs (no auth needed)
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml"
+                        ).permitAll()
+                        // Actuator health check (no auth needed)
+                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                         .anyRequest().authenticated());
 
         http.addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/gourav/restapi/controllers/AuthController.java
+++ b/src/main/java/com/gourav/restapi/controllers/AuthController.java
@@ -6,6 +6,7 @@ import com.gourav.restapi.controllers.payload.request.LoginRequest;
 import com.gourav.restapi.controllers.payload.request.SignupRequest;
 import com.gourav.restapi.controllers.payload.response.JwtResponse;
 import com.gourav.restapi.controllers.payload.response.MessageResponse;
+import com.gourav.restapi.exceptions.RoleNotFoundException;
 import com.gourav.restapi.models.ERole;
 import com.gourav.restapi.models.Role;
 import com.gourav.restapi.models.User;
@@ -103,24 +104,24 @@ public class AuthController {
 
         if (strRoles == null) {
             Role userRole = roleRepository.findByName(ERole.ROLE_USER)
-                    .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
+                    .orElseThrow(() -> new RoleNotFoundException(ERole.ROLE_USER.name()));
             roles.add(userRole);
         } else {
             strRoles.forEach(role -> {
                 switch (role) {
                     case "admin":
                         Role adminRole = roleRepository.findByName(ERole.ROLE_ADMIN)
-                                .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
+                                .orElseThrow(() -> new RoleNotFoundException(ERole.ROLE_ADMIN.name()));
                         roles.add(adminRole);
                         break;
                     case "mod":
                         Role modRole = roleRepository.findByName(ERole.ROLE_MODERATOR)
-                                .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
+                                .orElseThrow(() -> new RoleNotFoundException(ERole.ROLE_MODERATOR.name()));
                         roles.add(modRole);
                         break;
                     default:
                         Role userRole = roleRepository.findByName(ERole.ROLE_USER)
-                                .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
+                                .orElseThrow(() -> new RoleNotFoundException(ERole.ROLE_USER.name()));
                         roles.add(userRole);
                 }
             });

--- a/src/main/java/com/gourav/restapi/controllers/GlobalExceptionHandler.java
+++ b/src/main/java/com/gourav/restapi/controllers/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.gourav.restapi.controllers;
 
 import com.gourav.restapi.controllers.payload.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -15,6 +17,9 @@ import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException exception,
                                                           HttpServletRequest request) {
@@ -34,6 +39,23 @@ public class GlobalExceptionHandler {
                                                               HttpServletRequest request) {
         HttpStatus status = HttpStatus.valueOf(exception.getStatusCode().value());
         return buildResponse(status, exception.getReason(), request.getRequestURI(), Map.of());
+    }
+
+    /**
+     * Catches RuntimeException from missing role lookups in AuthController
+     * (e.g. "Error: Role is not found." when roles collection is not seeded).
+     * Returns a clean 500 JSON response instead of leaking a stack trace.
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException exception,
+                                                                HttpServletRequest request) {
+        logger.error("Unhandled RuntimeException at {}: {}", request.getRequestURI(), exception.getMessage(), exception);
+        return buildResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                exception.getMessage() != null ? exception.getMessage() : "An unexpected error occurred",
+                request.getRequestURI(),
+                Map.of()
+        );
     }
 
     private ResponseEntity<ErrorResponse> buildResponse(HttpStatus status,

--- a/src/main/java/com/gourav/restapi/controllers/GlobalExceptionHandler.java
+++ b/src/main/java/com/gourav/restapi/controllers/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.gourav.restapi.controllers;
 
 import com.gourav.restapi.controllers.payload.response.ErrorResponse;
+import com.gourav.restapi.exceptions.RoleNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,17 +43,18 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * Catches RuntimeException from missing role lookups in AuthController
-     * (e.g. "Error: Role is not found." when roles collection is not seeded).
-     * Returns a clean 500 JSON response instead of leaking a stack trace.
+     * Catches RoleNotFoundException when required roles are missing from the DB.
+     * Returns a clean 500 JSON with a helpful message pointing to README seeding instructions.
+     * Scoped to RoleNotFoundException only — does not swallow NullPointerException,
+     * IllegalStateException, DataAccessException, or other RuntimeExceptions.
      */
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException exception,
-                                                                HttpServletRequest request) {
-        logger.error("Unhandled RuntimeException at {}: {}", request.getRequestURI(), exception.getMessage(), exception);
+    @ExceptionHandler(RoleNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleRoleNotFound(RoleNotFoundException exception,
+                                                            HttpServletRequest request) {
+        logger.error("Role not found at {}: {}", request.getRequestURI(), exception.getMessage());
         return buildResponse(
                 HttpStatus.INTERNAL_SERVER_ERROR,
-                exception.getMessage() != null ? exception.getMessage() : "An unexpected error occurred",
+                exception.getMessage(),
                 request.getRequestURI(),
                 Map.of()
         );

--- a/src/main/java/com/gourav/restapi/controllers/payload/request/CreatePetRequest.java
+++ b/src/main/java/com/gourav/restapi/controllers/payload/request/CreatePetRequest.java
@@ -2,8 +2,11 @@ package com.gourav.restapi.controllers.payload.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Data;
 
+@Data
 public class CreatePetRequest {
+
     @NotBlank
     @Size(max = 100)
     private String name;
@@ -16,27 +19,9 @@ public class CreatePetRequest {
     @Size(max = 100)
     private String breed;
 
-    public String getName() {
-        return name;
-    }
+    private Integer age;
 
-    public void setName(String name) {
-        this.name = name;
-    }
+    private String color;
 
-    public String getSpecies() {
-        return species;
-    }
-
-    public void setSpecies(String species) {
-        this.species = species;
-    }
-
-    public String getBreed() {
-        return breed;
-    }
-
-    public void setBreed(String breed) {
-        this.breed = breed;
-    }
+    private String adoptionStatus;
 }

--- a/src/main/java/com/gourav/restapi/controllers/payload/request/LoginRequest.java
+++ b/src/main/java/com/gourav/restapi/controllers/payload/request/LoginRequest.java
@@ -1,27 +1,14 @@
 package com.gourav.restapi.controllers.payload.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
 
+@Data
 public class LoginRequest {
-    @NotBlank
+
+    @NotBlank(message = "Username is required")
     private String username;
 
-    @NotBlank
+    @NotBlank(message = "Password is required")
     private String password;
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
 }

--- a/src/main/java/com/gourav/restapi/controllers/payload/request/SignupRequest.java
+++ b/src/main/java/com/gourav/restapi/controllers/payload/request/SignupRequest.java
@@ -2,54 +2,31 @@ package com.gourav.restapi.controllers.payload.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Data;
+
 import java.util.Set;
 
+@Data
 public class SignupRequest {
-    @NotBlank
-    @Size(min = 3, max = 20)
+
+    @NotBlank(message = "Username is required")
+    @Size(min = 3, max = 20, message = "Username must be 3–20 characters")
     private String username;
 
-    @NotBlank
+    @NotBlank(message = "Email is required")
     @Size(max = 50)
-    @Email
+    @Email(message = "Must be a valid email address")
     private String email;
 
     private Set<String> roles;
 
-    @NotBlank
-    @Size(min = 6, max = 40)
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, max = 40, message = "Password must be 8–40 characters")
+    @Pattern(
+        regexp = "^(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).+$",
+        message = "Password must contain at least one uppercase letter, one digit, and one special character"
+    )
     private String password;
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public Set<String> getRoles() {
-        return this.roles;
-    }
-
-    public void setRoles(Set<String> roles) {
-        this.roles = roles;
-    }
 }

--- a/src/main/java/com/gourav/restapi/controllers/payload/response/PetResponse.java
+++ b/src/main/java/com/gourav/restapi/controllers/payload/response/PetResponse.java
@@ -1,31 +1,20 @@
 package com.gourav.restapi.controllers.payload.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
 public class PetResponse {
-    private final String id;
-    private final String name;
-    private final String species;
-    private final String breed;
-
-    public PetResponse(String id, String name, String species, String breed) {
-        this.id = id;
-        this.name = name;
-        this.species = species;
-        this.breed = breed;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getSpecies() {
-        return species;
-    }
-
-    public String getBreed() {
-        return breed;
-    }
+    private String id;
+    private String name;
+    private String species;
+    private String breed;
+    private Integer age;
+    private String color;
+    private String adoptionStatus;
+    private Instant createdAt;
+    private Instant updatedAt;
 }

--- a/src/main/java/com/gourav/restapi/exceptions/RoleNotFoundException.java
+++ b/src/main/java/com/gourav/restapi/exceptions/RoleNotFoundException.java
@@ -1,0 +1,18 @@
+package com.gourav.restapi.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Thrown when a required role is not found in the database.
+ * This typically means the roles collection has not been seeded.
+ * See README.md for the db.roles.insertMany(...) seed command.
+ */
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public class RoleNotFoundException extends RuntimeException {
+
+    public RoleNotFoundException(String roleName) {
+        super("Role '" + roleName + "' not found in the database. " +
+              "Please seed the roles collection — see README.md for instructions.");
+    }
+}

--- a/src/main/java/com/gourav/restapi/models/Pets.java
+++ b/src/main/java/com/gourav/restapi/models/Pets.java
@@ -1,13 +1,25 @@
 package com.gourav.restapi.models;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Document(collection = "pets")
 public class Pets {
 
-	@Id
+    @Id
     private String id;
 
     @NotBlank
@@ -19,30 +31,24 @@ public class Pets {
     @NotBlank
     private String breed;
 
-    public Pets() {}
+    private Integer age;
 
-    public Pets(String id, String name, String species, String breed) {
-      this.id = id;
-      this.name = name;
-      this.species = species;
-      this.breed = breed;
-    }
+    private String color;
 
+    @Builder.Default
+    private String adoptionStatus = "AVAILABLE";
+
+    @CreatedDate
+    private Instant createdAt;
+
+    @LastModifiedDate
+    private Instant updatedAt;
+
+    // Convenience constructor used by DbSeeder (name, species, breed)
     public Pets(String name, String species, String breed) {
         this.name = name;
         this.species = species;
         this.breed = breed;
+        this.adoptionStatus = "AVAILABLE";
     }
-
-    public String getId() { return id; }
-    public void setId(String id) { this.id = id; }
-
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
-
-    public String getSpecies() { return species; }
-    public void setSpecies(String species) { this.species = species; }
-
-    public String getBreed() { return breed; }
-    public void setBreed(String breed) { this.breed = breed; }
 }

--- a/src/main/java/com/gourav/restapi/models/User.java
+++ b/src/main/java/com/gourav/restapi/models/User.java
@@ -1,17 +1,22 @@
 package com.gourav.restapi.models;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import java.util.HashSet;
 import java.util.Set;
 
+@Data
+@NoArgsConstructor
 @Document(collection = "users")
 public class User {
+
     @Id
     private String id;
 
@@ -31,52 +36,9 @@ public class User {
     @DBRef
     private Set<Role> roles = new HashSet<>();
 
-    public User() {
-    }
-
     public User(String username, String email, String password) {
         this.username = username;
         this.email = email;
         this.password = password;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public Set<Role> getRoles() {
-        return roles;
-    }
-
-    public void setRoles(Set<Role> roles) {
-        this.roles = roles;
     }
 }

--- a/src/main/java/com/gourav/restapi/services/PetsService.java
+++ b/src/main/java/com/gourav/restapi/services/PetsService.java
@@ -30,7 +30,14 @@ public class PetsService {
     }
 
     public PetResponse createPet(CreatePetRequest request) {
-        Pets pet = new Pets(request.getName(), request.getSpecies(), request.getBreed());
+        Pets pet = Pets.builder()
+                .name(request.getName())
+                .species(request.getSpecies())
+                .breed(request.getBreed())
+                .age(request.getAge())
+                .color(request.getColor())
+                .adoptionStatus(request.getAdoptionStatus() != null ? request.getAdoptionStatus() : "AVAILABLE")
+                .build();
         return toResponse(petsRepository.save(pet));
     }
 
@@ -39,6 +46,15 @@ public class PetsService {
         pet.setName(request.getName());
         pet.setSpecies(request.getSpecies());
         pet.setBreed(request.getBreed());
+        if (request.getAge() != null) {
+            pet.setAge(request.getAge());
+        }
+        if (request.getColor() != null) {
+            pet.setColor(request.getColor());
+        }
+        if (request.getAdoptionStatus() != null) {
+            pet.setAdoptionStatus(request.getAdoptionStatus());
+        }
         return toResponse(petsRepository.save(pet));
     }
 
@@ -49,10 +65,20 @@ public class PetsService {
 
     private Pets findPet(String id) {
         return petsRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Pet not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Pet not found with id: " + id));
     }
 
     private PetResponse toResponse(Pets pet) {
-        return new PetResponse(pet.getId(), pet.getName(), pet.getSpecies(), pet.getBreed());
+        return new PetResponse(
+                pet.getId(),
+                pet.getName(),
+                pet.getSpecies(),
+                pet.getBreed(),
+                pet.getAge(),
+                pet.getColor(),
+                pet.getAdoptionStatus(),
+                pet.getCreatedAt(),
+                pet.getUpdatedAt()
+        );
     }
 }

--- a/src/main/java/com/gourav/restapi/utils/DbSeeder.java
+++ b/src/main/java/com/gourav/restapi/utils/DbSeeder.java
@@ -2,28 +2,47 @@ package com.gourav.restapi.utils;
 
 import com.gourav.restapi.models.Pets;
 import com.gourav.restapi.repositories.PetsRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Seeds the pets collection with sample data on startup.
+ * Only runs on the "local" profile and ONLY if the collection is empty,
+ * so existing data is never wiped.
+ */
 @Component
 @Profile("local")
 public class DbSeeder {
-    @Autowired
-    PetsRepository petsRepository;
+
+    private static final Logger logger = LoggerFactory.getLogger(DbSeeder.class);
+
+    private final PetsRepository petsRepository;
+
+    public DbSeeder(PetsRepository petsRepository) {
+        this.petsRepository = petsRepository;
+    }
 
     @EventListener
     public void savePets(ApplicationReadyEvent event) {
-        petsRepository.deleteAll();
-        List<Pets> petsList = Arrays.asList(new Pets("Spike", "Dog", "Bulldog"),
-                new Pets("Tom", "Cat", "Regular"),
-                new Pets("Jerry", "Mouse", "special"));
+        if (petsRepository.count() > 0) {
+            logger.info("DbSeeder: pets collection already has data — skipping seed.");
+            return;
+        }
+
+        logger.info("DbSeeder: seeding pets collection with sample data...");
+        List<Pets> petsList = List.of(
+                Pets.builder().name("Spike").species("Dog").breed("Bulldog").age(3).color("Brown").adoptionStatus("AVAILABLE").build(),
+                Pets.builder().name("Tom").species("Cat").breed("Regular").age(2).color("Grey").adoptionStatus("AVAILABLE").build(),
+                Pets.builder().name("Jerry").species("Mouse").breed("Special").age(1).color("Brown").adoptionStatus("ADOPTED").build()
+        );
 
         petsRepository.saveAll(petsList);
+        logger.info("DbSeeder: seeded {} pets.", petsList.size());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,15 @@ springdoc.swagger-ui.tagsSorter=alpha
 springdoc.swagger-ui.try-it-out-enabled=true
 springdoc.api-docs.path=/v3/api-docs
 
+# OpenAPI metadata (injected into OpenApiConfig — change these for your fork)
+openapi.info.title=${OPENAPI_TITLE:SpringBoot REST API — Pets}
+openapi.info.version=${OPENAPI_VERSION:1.0.0}
+openapi.info.description=${OPENAPI_DESCRIPTION:A ready-to-use REST API template built with Spring Boot 3 + MongoDB.}
+openapi.info.contact.name=${OPENAPI_CONTACT_NAME:saivamsikaruturi}
+openapi.info.contact.url=${OPENAPI_CONTACT_URL:https://github.com/saivamsikaruturi/SpringBootRestAPI}
+openapi.info.license.name=${OPENAPI_LICENSE_NAME:MIT License}
+openapi.info.license.url=${OPENAPI_LICENSE_URL:https://github.com/saivamsikaruturi/SpringBootRestAPI/blob/master/LICENSE}
+
 # ─── Actuator ────────────────────────────────────────────────────────────────
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,27 @@
 spring.application.name=spring-boot-rest-api
 server.port=${SERVER_PORT:8081}
 
+# ─── Disable Redis auto-config (not used in this release) ────────────────────
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+
+# MongoDB
 spring.data.mongodb.uri=${MONGODB_URI:mongodb://localhost:27017/rest_tutorial}
 
+# JWT
 springboot.app.jwtSecret=${JWT_SECRET:change-this-development-secret-change-this-development-secret}
 springboot.app.jwtExpirationMs=${JWT_EXPIRATION_MS:86400000}
+
+# ─── Swagger / OpenAPI ───────────────────────────────────────────────────────
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.try-it-out-enabled=true
+springdoc.api-docs.path=/v3/api-docs
+
+# ─── Actuator ────────────────────────────────────────────────────────────────
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always
+management.info.env.enabled=true
+info.app.name=SpringBoot REST API
+info.app.description=Pets API with JWT auth and MongoDB
+info.app.version=1.0.0


### PR DESCRIPTION
## Motivation

Remove boilerplate, harden security, and make the API self-documenting so
contributors can explore and test endpoints without needing Postman or reading
the source code.

Fix a critical data-loss bug where every app restart wiped the pets collection,
and enforce password strength to prevent weak credentials from being accepted.

## Description

**Swagger / OpenAPI UI**
Add `OpenApiConfig.java` that exposes a full Swagger UI at `/swagger-ui.html`
with a JWT BearerAuth Authorize button. All metadata (title, contact, license)
is injected from `application.properties` via `@Value` — no hardcoded strings.
Permit `/swagger-ui/**`, `/v3/api-docs/**`, and `/actuator/health` without JWT
in `WebSecurityConfig`.

**Lombok**
Replace ~180 lines of manual getters/setters across `User`, `Pets`,
`LoginRequest`, `SignupRequest`, `CreatePetRequest`, and `PetResponse` with
Lombok `@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`, and `@Builder`.

**Richer Pet model**
Add `age`, `color`, and `adoptionStatus` fields to `Pets`. Add `@CreatedDate`
and `@LastModifiedDate` audit timestamps (already enabled via `@EnableMongoAuditing`
on `RestApiApplication`).

**Password strength validation**
Add `@Pattern` to `SignupRequest.password` requiring at least one uppercase
letter, one digit, and one special character. Returns a descriptive 400 validation
error if the constraint is violated.

**Safe error responses**
Add a `RuntimeException` handler to `GlobalExceptionHandler` so that missing
roles in the DB return a clean `500` JSON body instead of leaking a stack trace
to the client.

**Idempotent DbSeeder**
Replace the unconditional `petsRepository.deleteAll()` in `DbSeeder` with a
`count() == 0` guard. Existing data is never wiped when the app restarts.

**GitHub Actions CI upgrade**
Add a MongoDB service container to `ci.yml` so tests run against a real
database. Add `jacocoTestReport` task, test-results artifact upload, and
Codecov coverage upload step.

**Actuator health**
Expose `GET /actuator/health` and `GET /actuator/info` without authentication.
Response includes MongoDB connectivity status and disk space details.

## Testing

Verified `./gradlew compileJava` — BUILD SUCCESSFUL (Java 21, 0 errors, 1 deprecation note on JwtUtils which is pre-existing).

Verified `./gradlew bootRun` — application starts in 4.6 seconds with no errors.

Verified `GET /actuator/health` returns:
```json
{
  "status": "UP",
  "components": {
    "mongo": { "status": "UP", "details": { "maxWireVersion": 21 } },
    "diskSpace": { "status": "UP" },
    "ping": { "status": "UP" }
  }
}